### PR TITLE
Fix hotspot-phone: problems related to hotspot start/stop

### DIFF
--- a/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyHotspotPhone.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyHotspotPhone.kt
@@ -19,10 +19,11 @@ class StrategyHotspotPhone(context: Context, private val scope: CoroutineScope) 
     override fun start() {
         Log.i(TAG, "Strategy: Hotspot Phone (TCP 5289 Trigger Listener)")
         
-        // Attempt to auto-enable hotspot (best effort)
+        // Only claim ownership if hotspot was known-off before we enabled it (see HotspotManager.isWifiHotspotActive).
+        val priorActive = HotspotManager.isWifiHotspotActive(context)
         val success = HotspotManager.setHotspotEnabled(context, true)
-        hotspotEnabledByUs = success
-        Log.i(TAG, "Auto-enable hotspot attempt finished. Success: $success")
+        hotspotEnabledByUs = success && (priorActive == false)
+        Log.i(TAG, "Auto-enable hotspot: priorActive=$priorActive success=$success hotspotEnabledByUs=$hotspotEnabledByUs")
         
         getStrategyScope().launch(Dispatchers.IO) {
             try {

--- a/app/src/main/java/com/andrerinas/wirelesshelper/utils/HotspotManager.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/utils/HotspotManager.kt
@@ -22,8 +22,32 @@ object HotspotManager {
     private const val TAG = "HUREV_WIFI"
     private const val CALLBACK_CLASS = "android.net.ConnectivityManager\$OnStartTetheringCallback"
 
+    /** AOSP [WifiManager] soft AP states (hidden API); used only via reflection. */
+    private const val WIFI_AP_STATE_ENABLING = 12
+    private const val WIFI_AP_STATE_ENABLED = 13
+
     // Cache the generated callback class so we only do bytecode generation once
     private var cachedCallbackClass: Class<*>? = null
+
+    /** Cached [WifiManager.getWifiApState] reflection; avoids repeated [Class.getMethod] lookups. */
+    private var getWifiApStateMethod: Method? = null
+
+    /**
+     * Whether Wi‑Fi hotspot (soft AP) is on or transitioning on, via [WifiManager.getWifiApState].
+     * Returns null if the method is missing or fails — callers should not assume we enabled hotspot.
+     */
+    fun isWifiHotspotActive(context: Context): Boolean? {
+        return try {
+            val wm = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            val method = getWifiApStateMethod
+                ?: wm.javaClass.getMethod("getWifiApState").also { getWifiApStateMethod = it }
+            val state = method.invoke(wm) as Int
+            state == WIFI_AP_STATE_ENABLED || state == WIFI_AP_STATE_ENABLING
+        } catch (e: Exception) {
+            Log.d(TAG, "[HotspotManager] getWifiApState unavailable: ${e.message}")
+            null
+        }
+    }
 
     fun setHotspotEnabled(context: Context, enabled: Boolean): Boolean {
         Log.i(TAG, "[HotspotManager] Setting hotspot: $enabled (API ${Build.VERSION.SDK_INT})")


### PR DESCRIPTION
Do not stop hotspot if it is enabled before starting the app

A logic implementation issue. Previously, if there is no error in the best effort hotspot enabled function, it is considered that the hotspot is started by this app. This is not correct because when the hotspot is already started, the best effort hotspot enabled function has no error too. The proposed fix is to check explicitly whether the hotspot is already active before or not.

Tested on my Nokia G20 - Android 13