### PR TITLE
Add WiFi auto-connect for Tablet Hotspot mode (Android 10+)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ android {
         }
         getByName("debug") {
             isDebuggable = true
+            applicationIdSuffix = ".debug"
         }
     }
     

--- a/app/src/main/java/com/andrerinas/wirelesshelper/MainActivity.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/MainActivity.kt
@@ -53,6 +53,8 @@ class MainActivity : AppCompatActivity() {
     private lateinit var tvConnectionModeValue: TextView
     private lateinit var layoutStaticIp: View
     private lateinit var tvStaticIpValue: TextView
+    private lateinit var layoutHotspotCredentials: View
+    private lateinit var tvHotspotCredentialsValue: TextView
     private lateinit var layoutAutoStart: View
     private lateinit var tvAutoStartValue: TextView
     private lateinit var layoutBluetoothDevice: View
@@ -168,6 +170,8 @@ class MainActivity : AppCompatActivity() {
         tvConnectionModeValue = findViewById(R.id.tvConnectionModeValue)
         layoutStaticIp = findViewById(R.id.layoutStaticIp)
         tvStaticIpValue = findViewById(R.id.tvStaticIpValue)
+        layoutHotspotCredentials = findViewById(R.id.layoutHotspotCredentials)
+        tvHotspotCredentialsValue = findViewById(R.id.tvHotspotCredentialsValue)
         layoutAutoStart = findViewById(R.id.layoutAutoStart)
         tvAutoStartValue = findViewById(R.id.tvAutoStartValue)
         layoutBluetoothDevice = findViewById(R.id.layoutBluetoothDevice)
@@ -202,7 +206,8 @@ class MainActivity : AppCompatActivity() {
         layoutLanguage.setOnClickListener { showLanguageSelector() }
 
         layoutStaticIp.setOnClickListener { showStaticIpDialog() }
-        
+        layoutHotspotCredentials.setOnClickListener { showHotspotCredentialsDialog() }
+
         layoutExportLog.setOnClickListener { exportLogs() }
 
         btnToggleService.setOnClickListener {
@@ -326,6 +331,45 @@ class MainActivity : AppCompatActivity() {
         val prefs = getSharedPreferences("WirelessHelperPrefs", Context.MODE_PRIVATE)
         val ip = prefs.getString("static_ip_address", "") ?: ""
         tvStaticIpValue.text = if (ip.isEmpty()) getString(R.string.not_set) else ip
+    }
+
+    private fun showHotspotCredentialsDialog() {
+        val prefs = getSharedPreferences("WirelessHelperPrefs", Context.MODE_PRIVATE)
+        val securePrefs = com.andrerinas.wirelesshelper.utils.Prefs.getSecure(this)
+        val currentSsid = prefs.getString("hotspot_ssid", "") ?: ""
+        val currentPassword = securePrefs.getString("hotspot_password", "") ?: ""
+
+        val dialogView = LayoutInflater.from(this).inflate(R.layout.layout_hotspot_credentials_dialog, null)
+        val etSsid = dialogView.findViewById<com.google.android.material.textfield.TextInputEditText>(R.id.et_hotspot_ssid)
+        val etPassword = dialogView.findViewById<com.google.android.material.textfield.TextInputEditText>(R.id.et_hotspot_password)
+
+        etSsid.setText(currentSsid)
+        etPassword.setText(currentPassword)
+
+        MaterialAlertDialogBuilder(this, R.style.DarkAlertDialog)
+            .setTitle(R.string.hotspot_credentials_dialog_title)
+            .setMessage(R.string.hotspot_credentials_dialog_msg)
+            .setView(dialogView)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                val newSsid = etSsid.text.toString().trim()
+                val newPassword = etPassword.text.toString()
+                prefs.edit { putString("hotspot_ssid", newSsid) }
+                securePrefs.edit { putString("hotspot_password", newPassword) }
+                updateHotspotCredentialsDisplay()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .setNeutralButton(R.string.reset) { _, _ ->
+                prefs.edit { remove("hotspot_ssid") }
+                securePrefs.edit { remove("hotspot_password") }
+                updateHotspotCredentialsDisplay()
+            }
+            .show()
+    }
+
+    private fun updateHotspotCredentialsDisplay() {
+        val prefs = getSharedPreferences("WirelessHelperPrefs", Context.MODE_PRIVATE)
+        val ssid = prefs.getString("hotspot_ssid", "") ?: ""
+        tvHotspotCredentialsValue.text = if (ssid.isEmpty()) getString(R.string.not_set) else ssid
     }
 
     private fun showBluetoothDeviceSelector() {
@@ -480,6 +524,7 @@ class MainActivity : AppCompatActivity() {
         tvConnectionModeValue.text = connectionModes.getOrElse(connMode) { connectionModes[0] }
         updateModeSpecificUI(connMode)
         updateStaticIpDisplay()
+        updateHotspotCredentialsDisplay()
         val autoMode = prefs.getInt("auto_start_mode", 0)
         updateAutoStartUI(autoMode)
         updateBluetoothValueDisplay()
@@ -544,6 +589,7 @@ class MainActivity : AppCompatActivity() {
     private fun updateModeSpecificUI(mode: Int) {
         layoutHotspotForceStop.visibility = if (mode == MODE_HOTSPOT_PHONE) View.VISIBLE else View.GONE
         layoutStaticIp.visibility = if (mode == MODE_PASSIVE) View.VISIBLE else View.GONE
+        layoutHotspotCredentials.visibility = if (mode == MODE_PASSIVE) View.VISIBLE else View.GONE
         layoutWifiDirectName.visibility = if (mode == MODE_WIFI_DIRECT) View.VISIBLE else View.GONE
         // For nearby, we might want to hide other things or show a specific hint in the future.
     }

--- a/app/src/main/java/com/andrerinas/wirelesshelper/net/HotspotAutoConnect.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/net/HotspotAutoConnect.kt
@@ -1,0 +1,184 @@
+package com.andrerinas.wirelesshelper.net
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+/**
+ * Handles programmatic connection to a WiFi hotspot using WifiNetworkSpecifier (Android 10+).
+ *
+ * First connection shows a system dialog for user approval; subsequent connections are automatic.
+ */
+object HotspotAutoConnect {
+
+    private const val TAG = "HUREV_HOTSPOT_CONNECT"
+    private const val CONNECTION_TIMEOUT_MS = 30_000L
+
+    sealed class Result {
+        data class Connected(val network: Network, val gateway: String?) : Result()
+        data object UserDeclined : Result()
+        data object NetworkNotFound : Result()
+        data object Timeout : Result()
+        data object UnsupportedApi : Result()
+    }
+
+    private var activeCallback: ConnectivityManager.NetworkCallback? = null
+    private var connectivityManager: ConnectivityManager? = null
+
+    @Volatile
+    var currentNetwork: Network? = null
+        private set
+
+    /**
+     * Attempts to connect to a WiFi hotspot with the given credentials.
+     *
+     * @param context Application context
+     * @param ssid The SSID of the hotspot to connect to
+     * @param password The WPA2/WPA3 password for the hotspot
+     * @return Result indicating success or failure reason
+     */
+    suspend fun connect(context: Context, ssid: String, password: String): Result {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            Log.w(TAG, "WifiNetworkSpecifier requires Android 10+")
+            return Result.UnsupportedApi
+        }
+
+        return connectInternal(context, ssid, password)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private suspend fun connectInternal(context: Context, ssid: String, password: String): Result {
+        // Release any previous request
+        release()
+
+        val cm = context.applicationContext
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        connectivityManager = cm
+
+        val specifier = WifiNetworkSpecifier.Builder()
+            .setSsid(ssid)
+            .setWpa2Passphrase(password)
+            .build()
+
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .setNetworkSpecifier(specifier)
+            .build()
+
+        Log.i(TAG, "Requesting connection to hotspot: $ssid")
+
+        val result = withTimeoutOrNull(CONNECTION_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                val callback = object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        Log.i(TAG, "Connected to hotspot: $ssid")
+                        currentNetwork = network
+                        // Bind process to this network so sockets use it
+                        cm.bindProcessToNetwork(network)
+
+                        // Log gateway info for debugging
+                        val gateway = getGatewayAddress(cm, network)
+                        Log.i(TAG, "=== HOTSPOT CONNECTED ===")
+                        Log.i(TAG, "Network: $network")
+                        Log.i(TAG, "Gateway (headunit): $gateway")
+                        Log.i(TAG, "=========================")
+
+                        if (continuation.isActive) {
+                            continuation.resume(Result.Connected(network, gateway))
+                        }
+                    }
+
+                    override fun onLost(network: Network) {
+                        // Android may report transient "lost" during handoff or signal fluctuation.
+                        // Unbinding here would route traffic to home WiFi, breaking AA.
+                        // Stay bound - if hotspot recovers, we're ready; if not, sockets fail visibly.
+                        Log.w(TAG, "Hotspot connection lost (staying bound): $ssid")
+                    }
+
+                    override fun onUnavailable() {
+                        Log.w(TAG, "Hotspot unavailable (user declined or not found): $ssid")
+                        release()
+                        if (continuation.isActive) {
+                            continuation.resume(Result.UserDeclined)
+                        }
+                    }
+                }
+
+                activeCallback = callback
+
+                continuation.invokeOnCancellation {
+                    Log.d(TAG, "Connection request cancelled")
+                    release()
+                }
+
+                try {
+                    cm.requestNetwork(request, callback)
+                } catch (e: SecurityException) {
+                    Log.e(TAG, "requestNetwork failed: ${e.message}")
+                    release()
+                    if (continuation.isActive) {
+                        continuation.resume(Result.NetworkNotFound)
+                    }
+                }
+            }
+        }
+
+        return result ?: Result.Timeout.also {
+            Log.w(TAG, "Connection timed out for: $ssid")
+            release()
+        }
+    }
+
+    /**
+     * Releases the network request and unbinds from the network.
+     */
+    fun release() {
+        val cm = connectivityManager
+        val cb = activeCallback
+
+        if (cb != null && cm != null) {
+            try {
+                cm.unregisterNetworkCallback(cb)
+                Log.d(TAG, "Network callback unregistered")
+            } catch (e: Exception) {
+                Log.w(TAG, "unregisterNetworkCallback: ${e.message}")
+            }
+        }
+
+        if (cm != null) {
+            try {
+                cm.bindProcessToNetwork(null)
+            } catch (e: Exception) {
+                Log.w(TAG, "bindProcessToNetwork(null): ${e.message}")
+            }
+        }
+
+        activeCallback = null
+        connectivityManager = null
+        currentNetwork = null
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun getGatewayAddress(cm: ConnectivityManager, network: Network): String? {
+        return try {
+            val linkProps = cm.getLinkProperties(network)
+            linkProps?.routes
+                ?.find { it.isDefaultRoute && it.gateway is java.net.Inet4Address }
+                ?.gateway
+                ?.hostAddress
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to get gateway: ${e.message}")
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/andrerinas/wirelesshelper/net/HotspotAutoConnect.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/net/HotspotAutoConnect.kt
@@ -1,0 +1,163 @@
+package com.andrerinas.wirelesshelper.net
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+/**
+ * Handles programmatic connection to a WiFi hotspot using WifiNetworkSpecifier (Android 10+).
+ *
+ * First connection shows a system dialog for user approval; subsequent connections are automatic.
+ */
+object HotspotAutoConnect {
+
+    private const val TAG = "HUREV_HOTSPOT_CONNECT"
+    private const val CONNECTION_TIMEOUT_MS = 30_000L
+
+    sealed class Result {
+        data class Connected(val network: Network) : Result()
+        data object UserDeclined : Result()
+        data object NetworkNotFound : Result()
+        data object Timeout : Result()
+        data object UnsupportedApi : Result()
+    }
+
+    private var activeCallback: ConnectivityManager.NetworkCallback? = null
+    private var connectivityManager: ConnectivityManager? = null
+
+    @Volatile
+    var currentNetwork: Network? = null
+        private set
+
+    /**
+     * Attempts to connect to a WiFi hotspot with the given credentials.
+     *
+     * @param context Application context
+     * @param ssid The SSID of the hotspot to connect to
+     * @param password The WPA2/WPA3 password for the hotspot
+     * @return Result indicating success or failure reason
+     */
+    suspend fun connect(context: Context, ssid: String, password: String): Result {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            Log.w(TAG, "WifiNetworkSpecifier requires Android 10+")
+            return Result.UnsupportedApi
+        }
+
+        return connectInternal(context, ssid, password)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private suspend fun connectInternal(context: Context, ssid: String, password: String): Result {
+        // Release any previous request
+        release()
+
+        val cm = context.applicationContext
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        connectivityManager = cm
+
+        val specifier = WifiNetworkSpecifier.Builder()
+            .setSsid(ssid)
+            .setWpa2Passphrase(password)
+            .build()
+
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .setNetworkSpecifier(specifier)
+            .build()
+
+        Log.i(TAG, "Requesting connection to hotspot: $ssid")
+
+        val result = withTimeoutOrNull(CONNECTION_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                val callback = object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        Log.i(TAG, "Connected to hotspot: $ssid")
+                        currentNetwork = network
+                        // Bind process to this network so sockets use it
+                        cm.bindProcessToNetwork(network)
+                        if (continuation.isActive) {
+                            continuation.resume(Result.Connected(network))
+                        }
+                    }
+
+                    override fun onLost(network: Network) {
+                        Log.i(TAG, "Hotspot connection lost: $ssid")
+                        if (currentNetwork == network) {
+                            currentNetwork = null
+                            cm.bindProcessToNetwork(null)
+                        }
+                    }
+
+                    override fun onUnavailable() {
+                        Log.w(TAG, "Hotspot unavailable (user declined or not found): $ssid")
+                        release()
+                        if (continuation.isActive) {
+                            continuation.resume(Result.UserDeclined)
+                        }
+                    }
+                }
+
+                activeCallback = callback
+
+                continuation.invokeOnCancellation {
+                    Log.d(TAG, "Connection request cancelled")
+                    release()
+                }
+
+                try {
+                    cm.requestNetwork(request, callback)
+                } catch (e: SecurityException) {
+                    Log.e(TAG, "requestNetwork failed: ${e.message}")
+                    release()
+                    if (continuation.isActive) {
+                        continuation.resume(Result.NetworkNotFound)
+                    }
+                }
+            }
+        }
+
+        return result ?: Result.Timeout.also {
+            Log.w(TAG, "Connection timed out for: $ssid")
+            release()
+        }
+    }
+
+    /**
+     * Releases the network request and unbinds from the network.
+     */
+    fun release() {
+        val cm = connectivityManager
+        val cb = activeCallback
+
+        if (cb != null && cm != null) {
+            try {
+                cm.unregisterNetworkCallback(cb)
+                Log.d(TAG, "Network callback unregistered")
+            } catch (e: Exception) {
+                Log.w(TAG, "unregisterNetworkCallback: ${e.message}")
+            }
+        }
+
+        if (cm != null) {
+            try {
+                cm.bindProcessToNetwork(null)
+            } catch (e: Exception) {
+                Log.w(TAG, "bindProcessToNetwork(null): ${e.message}")
+            }
+        }
+
+        activeCallback = null
+        connectivityManager = null
+        currentNetwork = null
+    }
+}

--- a/app/src/main/java/com/andrerinas/wirelesshelper/strategy/BaseStrategy.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/strategy/BaseStrategy.kt
@@ -9,6 +9,7 @@ import android.os.Parcelable
 import android.util.Log
 import com.andrerinas.wirelesshelper.TransparentTriggerActivity
 import com.andrerinas.wirelesshelper.connection.AapProxy
+import com.andrerinas.wirelesshelper.net.HotspotAutoConnect
 import com.andrerinas.wirelesshelper.net.WifiNetworkBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -54,11 +55,13 @@ abstract class BaseStrategy(protected val context: Context, private val scope: C
 
         scope.launch {
             try {
+                val hotspotNetwork = HotspotAutoConnect.currentNetwork
                 val boundWifi = WifiNetworkBinding.currentNetwork
 
                 val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-                
+
                 val targetNetwork = when {
+                    hotspotNetwork != null -> hotspotNetwork
                     boundWifi != null -> boundWifi
                     else -> (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) connectivityManager.activeNetwork else null)
                 }

--- a/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyHotspotTablet.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyHotspotTablet.kt
@@ -1,7 +1,10 @@
 package com.andrerinas.wirelesshelper.strategy
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
+import com.andrerinas.wirelesshelper.net.HotspotAutoConnect
+import com.andrerinas.wirelesshelper.utils.Prefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
@@ -26,21 +29,93 @@ class StrategyHotspotTablet(context: Context, private val scope: CoroutineScope)
             return
         }
 
-        Log.i(TAG, "Strategy: Hotspot Tablet (Passive TCP Listener)")
+        // Check for hotspot auto-connect credentials
+        val hotspotSsid = prefs.getString("hotspot_ssid", "") ?: ""
+        val hotspotPassword = if (hotspotSsid.isNotEmpty()) {
+            Prefs.getSecure(context).getString("hotspot_password", "") ?: ""
+        } else ""
+
+        if (hotspotSsid.isNotEmpty() && hotspotPassword.isNotEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            Log.i(TAG, "Strategy: Hotspot Tablet (Auto-Connect to $hotspotSsid)")
+            startWithAutoConnect(hotspotSsid, hotspotPassword)
+        } else {
+            Log.i(TAG, "Strategy: Hotspot Tablet (Passive TCP Listener)")
+            startTcpListener()
+        }
+    }
+
+    private fun startWithAutoConnect(ssid: String, password: String) {
+        getStrategyScope().launch(Dispatchers.IO) {
+            val result = HotspotAutoConnect.connect(context, ssid, password)
+
+            when (result) {
+                is HotspotAutoConnect.Result.Connected -> {
+                    val gateway = result.gateway
+                    Log.i(TAG, "Connected to hotspot, gateway=$gateway")
+
+                    // Try direct connection to headunit first
+                    if (gateway != null) {
+                        if (tryDirectConnect(gateway)) {
+                            Log.i(TAG, "Direct connection to headunit succeeded")
+                        } else {
+                            Log.w(TAG, "Direct connect failed, falling back to TCP listener")
+                            startTcpListener()
+                        }
+                    } else {
+                        Log.w(TAG, "No gateway detected, falling back to TCP listener")
+                        startTcpListener()
+                    }
+                }
+                is HotspotAutoConnect.Result.UserDeclined -> {
+                    Log.w(TAG, "User declined hotspot connection, falling back to passive listener")
+                    startTcpListener()
+                }
+                is HotspotAutoConnect.Result.NetworkNotFound -> {
+                    Log.w(TAG, "Hotspot not found, falling back to passive listener")
+                    startTcpListener()
+                }
+                is HotspotAutoConnect.Result.Timeout -> {
+                    Log.w(TAG, "Hotspot connection timed out, falling back to passive listener")
+                    startTcpListener()
+                }
+                is HotspotAutoConnect.Result.UnsupportedApi -> {
+                    Log.w(TAG, "WifiNetworkSpecifier not supported, using passive listener")
+                    startTcpListener()
+                }
+            }
+        }
+    }
+
+    private fun tryDirectConnect(gateway: String): Boolean {
+        val port = 5288
+        return try {
+            Log.i(TAG, "Attempting direct connection to $gateway:$port")
+            val socket = java.net.Socket()
+            socket.connect(InetSocketAddress(gateway, port), 3000)
+            Log.i(TAG, "Direct connection established to headunit")
+            launchAndroidAuto(gateway, socket)
+            true
+        } catch (e: Exception) {
+            Log.w(TAG, "Direct connection to $gateway:$port failed: ${e.javaClass.simpleName}: ${e.message}")
+            false
+        }
+    }
+
+    private fun startTcpListener() {
         getStrategyScope().launch(Dispatchers.IO) {
             try {
                 serverSocket = ServerSocket().apply {
                     reuseAddress = true
                     bind(InetSocketAddress(PORT_DISCOVERY))
                 }
+                Log.i(TAG, "TCP listener started on port $PORT_DISCOVERY")
                 while (isActive) {
                     val client = serverSocket?.accept()
                     val remoteIp = client?.inetAddress?.hostAddress
                     client?.close()
-                    
+
                     if (remoteIp != null) {
                         Log.i(TAG, "Trigger from $remoteIp")
-                        // In Tablet Hotspot mode, we use normal network routing (false for FakeNet)
                         launchAndroidAuto(remoteIp)
                     }
                 }
@@ -50,8 +125,14 @@ class StrategyHotspotTablet(context: Context, private val scope: CoroutineScope)
         }
     }
 
-    override fun stop() {
+    override fun stopForLaunch() {
+        // Only close TCP listener, keep hotspot connection alive for the proxy
         try { serverSocket?.close() } catch (e: Exception) {}
         serverSocket = null
+    }
+
+    override fun stop() {
+        HotspotAutoConnect.release()
+        stopForLaunch()
     }
 }

--- a/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyHotspotTablet.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyHotspotTablet.kt
@@ -1,7 +1,10 @@
 package com.andrerinas.wirelesshelper.strategy
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
+import com.andrerinas.wirelesshelper.net.HotspotAutoConnect
+import com.andrerinas.wirelesshelper.utils.Prefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.isActive
@@ -26,21 +29,65 @@ class StrategyHotspotTablet(context: Context, private val scope: CoroutineScope)
             return
         }
 
-        Log.i(TAG, "Strategy: Hotspot Tablet (Passive TCP Listener)")
+        // Check for hotspot auto-connect credentials
+        val hotspotSsid = prefs.getString("hotspot_ssid", "") ?: ""
+        val hotspotPassword = if (hotspotSsid.isNotEmpty()) {
+            Prefs.getSecure(context).getString("hotspot_password", "") ?: ""
+        } else ""
+
+        if (hotspotSsid.isNotEmpty() && hotspotPassword.isNotEmpty() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            Log.i(TAG, "Strategy: Hotspot Tablet (Auto-Connect to $hotspotSsid)")
+            startWithAutoConnect(hotspotSsid, hotspotPassword)
+        } else {
+            Log.i(TAG, "Strategy: Hotspot Tablet (Passive TCP Listener)")
+            startTcpListener()
+        }
+    }
+
+    private fun startWithAutoConnect(ssid: String, password: String) {
+        getStrategyScope().launch(Dispatchers.IO) {
+            val result = HotspotAutoConnect.connect(context, ssid, password)
+
+            when (result) {
+                is HotspotAutoConnect.Result.Connected -> {
+                    Log.i(TAG, "Connected to hotspot, starting TCP listener")
+                    startTcpListener()
+                }
+                is HotspotAutoConnect.Result.UserDeclined -> {
+                    Log.w(TAG, "User declined hotspot connection, falling back to passive listener")
+                    startTcpListener()
+                }
+                is HotspotAutoConnect.Result.NetworkNotFound -> {
+                    Log.w(TAG, "Hotspot not found, falling back to passive listener")
+                    startTcpListener()
+                }
+                is HotspotAutoConnect.Result.Timeout -> {
+                    Log.w(TAG, "Hotspot connection timed out, falling back to passive listener")
+                    startTcpListener()
+                }
+                is HotspotAutoConnect.Result.UnsupportedApi -> {
+                    Log.w(TAG, "WifiNetworkSpecifier not supported, using passive listener")
+                    startTcpListener()
+                }
+            }
+        }
+    }
+
+    private fun startTcpListener() {
         getStrategyScope().launch(Dispatchers.IO) {
             try {
                 serverSocket = ServerSocket().apply {
                     reuseAddress = true
                     bind(InetSocketAddress(PORT_DISCOVERY))
                 }
+                Log.i(TAG, "TCP listener started on port $PORT_DISCOVERY")
                 while (isActive) {
                     val client = serverSocket?.accept()
                     val remoteIp = client?.inetAddress?.hostAddress
                     client?.close()
-                    
+
                     if (remoteIp != null) {
                         Log.i(TAG, "Trigger from $remoteIp")
-                        // In Tablet Hotspot mode, we use normal network routing (false for FakeNet)
                         launchAndroidAuto(remoteIp)
                     }
                 }
@@ -50,8 +97,14 @@ class StrategyHotspotTablet(context: Context, private val scope: CoroutineScope)
         }
     }
 
-    override fun stop() {
+    override fun stopForLaunch() {
+        // Only close TCP listener, keep hotspot connection alive for the proxy
         try { serverSocket?.close() } catch (e: Exception) {}
         serverSocket = null
+    }
+
+    override fun stop() {
+        HotspotAutoConnect.release()
+        stopForLaunch()
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -167,6 +167,38 @@
                         android:textSize="14sp"/>
                 </LinearLayout>
 
+                <!-- 1c. Hotspot Auto-Connect (Hidden by default, shown if mode 2) -->
+                <LinearLayout
+                    android:id="@+id/layoutHotspotCredentials"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="14dp"
+                    android:layout_marginBottom="2dp"
+                    android:background="@drawable/bg_item_middle"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:visibility="gone">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/hotspot_credentials_label"
+                        android:textColor="@color/text_title"
+                        android:textSize="16sp"
+                        android:textStyle="normal"
+                        android:layout_marginBottom="2dp"/>
+
+                    <TextView
+                        android:id="@+id/tvHotspotCredentialsValue"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/not_set"
+                        android:textColor="@color/text_subtitle"
+                        android:textSize="14sp"/>
+                </LinearLayout>
+
                 <!-- 2. WiFi Direct Name (Hidden by default, shown if mode 3) -->
                 <LinearLayout
                     android:id="@+id/layoutWifiDirectName"

--- a/app/src/main/res/layout/layout_hotspot_credentials_dialog.xml
+++ b/app/src/main/res/layout/layout_hotspot_credentials_dialog.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        app:boxBackgroundMode="outline"
+        app:boxStrokeColor="@color/brand_teal"
+        app:hintTextColor="@color/brand_teal">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_hotspot_ssid"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hotspot_ssid_hint"
+            android:inputType="text"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:boxBackgroundMode="outline"
+        app:boxStrokeColor="@color/brand_teal"
+        app:hintTextColor="@color/brand_teal"
+        app:endIconMode="password_toggle">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/et_hotspot_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hotspot_password_hint"
+            android:inputType="textPassword"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,14 @@
     <string name="static_ip_dialog_title">Configure Static IP</string>
     <string name="reset">Reset</string>
 
+    <!-- Hotspot Auto-Connect (Tablet Hotspot mode) -->
+    <string name="hotspot_credentials_label">Hotspot Auto-Connect</string>
+    <string name="hotspot_credentials_desc">Automatically connect to the headunit\'s WiFi hotspot</string>
+    <string name="hotspot_credentials_dialog_title">Hotspot Credentials</string>
+    <string name="hotspot_credentials_dialog_msg">Enter the headunit hotspot\'s SSID and password. On first connection, Android will show a confirmation dialog.</string>
+    <string name="hotspot_ssid_hint">SSID (e.g. AndroidAP)</string>
+    <string name="hotspot_password_hint">Password</string>
+
     <!-- Auto Start -->
     <string name="auto_start_label">Auto Start Service</string>
     <string name="auto_start_no">No (Manual)</string>

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  build:
+    image: docker.io/cimg/android:2024.01
+    working_dir: /project
+    user: root
+    volumes:
+      - .:/project:Z
+      - gradle-cache:/root/.gradle
+      - debug-keystore:/root/.android
+    command: ./gradlew assembleDebug --no-daemon
+
+volumes:
+  gradle-cache:
+  debug-keystore:


### PR DESCRIPTION
Closes #40

## Summary

Uses WifiNetworkSpecifier API (Android 10+) to programmatically connect phone to headunit's WiFi hotspot. First connection shows system approval dialog; subsequent connections are automatic.

On devices with dual-STA support, the hotspot connection runs in parallel to regular WiFi - phone's normal internet access is not impacted (unlike manual hotspot connection).

**New:** After connecting to hotspot, attempts direct TCP connection to headunit on port 5288 using detected gateway address. Falls back to passive TCP listener if direct connect fails.

## How it works

1. User configures hotspot SSID + password in settings (stored encrypted)
2. On start, `StrategyHotspotTablet` calls `HotspotAutoConnect.connect()` with credentials
3. Android shows system dialog for first-time approval
4. On connection, process is bound to hotspot network so AA traffic routes correctly
5. Detects gateway IP and attempts direct connection to headunit:5288
6. Falls back to passive TCP listener if direct connect fails or credentials not set

## Changes

- New `HotspotAutoConnect` utility using NetworkRequest API with gateway detection
- Direct headunit connection via gateway:5288 before falling back to TCP listener
- Settings UI for entering hotspot SSID/password (stored via EncryptedSharedPreferences)
- Override `stopForLaunch()` in tablet strategy to keep hotspot connection alive during proxy
- Fixed `onLost` callback to stay bound during transient signal fluctuations
- Debug builds install alongside release (`.debug` suffix)
- Added `compose.yaml` for reproducible Docker builds with gradle caching

## Testing

Tested locally - direct connection to headunit works, AA launches successfully.