### PR TITLE
Slow WiFi direct connect

### DIFF
--- a/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyWifiDirect.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyWifiDirect.kt
@@ -116,17 +116,22 @@ class StrategyWifiDirect(context: Context, scope: CoroutineScope) : BaseStrategy
         context.registerReceiver(p2pReceiver, intentFilter)
         
         // Remove WiFi direct group and start the continuous discovery loop
-        p2pManager?.removeGroup(p2pChannel, object : WifiP2pManager.ActionListener {
-            override fun onSuccess() {
-                Log.i(TAG, "Old P2P group removed")
-                startDiscoveryLoop()
-            }
+        val channel = p2pChannel
+        if (channel != null) {
+            p2pManager?.removeGroup(channel, object : WifiP2pManager.ActionListener {
+                override fun onSuccess() {
+                    Log.i(TAG, "Old P2P group removed")
+                    startDiscoveryLoop()
+                }
 
-            override fun onFailure(reason: Int) {
-                Log.i(TAG, "removeGroup failed ($reason)")
-                startDiscoveryLoop()
-            }
-        })
+                override fun onFailure(reason: Int) {
+                    Log.i(TAG, "removeGroup failed ($reason)")
+                    startDiscoveryLoop()
+                }
+            })
+        } else {
+            startDiscoveryLoop()
+        }
     }
 
     private fun startDiscoveryLoop() {
@@ -135,7 +140,7 @@ class StrategyWifiDirect(context: Context, scope: CoroutineScope) : BaseStrategy
                 if (!isConnectingToPeer && !isLaunching.get()) {
                     discoverPeers()
                 }
-                delay(30000) // Restart discovery every 30 seconds
+                delay(5000) // Restart discovery every 5 seconds
             }
         }
     }

--- a/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyWifiDirect.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyWifiDirect.kt
@@ -115,8 +115,18 @@ class StrategyWifiDirect(context: Context, scope: CoroutineScope) : BaseStrategy
 
         context.registerReceiver(p2pReceiver, intentFilter)
         
-        // Start the continuous discovery loop
-        startDiscoveryLoop()
+        // Remove WiFi direct group and start the continuous discovery loop
+        p2pManager?.removeGroup(p2pChannel, object : WifiP2pManager.ActionListener {
+            override fun onSuccess() {
+                Log.i(TAG, "Old P2P group removed")
+                startDiscoveryLoop()
+            }
+
+            override fun onFailure(reason: Int) {
+                Log.i(TAG, "removeGroup failed ($reason)")
+                startDiscoveryLoop()
+            }
+        })
     }
 
     private fun startDiscoveryLoop() {


### PR DESCRIPTION
fix: remove existing Wi-Fi Direct group before starting discovery loop