### PR TITLE
Fix "Connected" status getting stuck after the tablet disconnects

### DIFF
--- a/app/src/main/java/com/andrerinas/wirelesshelper/connection/AapProxy.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/connection/AapProxy.kt
@@ -77,9 +77,19 @@ class AapProxy(
                 val tabletIn = tabletSocket.getInputStream()
                 val tabletOut = tabletSocket.getOutputStream()
 
-                // Two-way pump
-                val job1 = launch { pump(aaIn, tabletOut, "AA -> Tablet") }
-                val job2 = launch { pump(tabletIn, aaOut, "Tablet -> AA") }
+                // Each direction force-closes BOTH sockets as soon as it ends (source hung up
+                // or errored) — this is what unblocks whichever pump is still stuck in a
+                // blocking read() on its own end, so joinAll() below can't deadlock waiting on
+                // a peer (e.g. Google's AA app) that never proactively closes its socket on
+                // its own after the tablet side hangs up.
+                val job1 = launch {
+                    pump(aaIn, tabletOut, "AA -> Tablet")
+                    closeBridgeSockets(aaSocket, tabletSocket)
+                }
+                val job2 = launch {
+                    pump(tabletIn, aaOut, "Tablet -> AA")
+                    closeBridgeSockets(aaSocket, tabletSocket)
+                }
 
                 joinAll(job1, job2)
             } catch (e: Exception) {
@@ -87,14 +97,21 @@ class AapProxy(
             } finally {
                 Log.i(TAG, "Bridge closed")
                 activeTabletSocket = null
-                try { aaSocket.close() } catch (e: Exception) {}
-                try { tabletSocket?.close() } catch (e: Exception) {}
-                
+                closeBridgeSockets(aaSocket, tabletSocket)
+
                 if (activeBridges.decrementAndGet() <= 0) {
                     listener?.onDisconnected()
                 }
             }
         }
+    }
+
+    /** Force-closes both ends of the bridge. Safe to call repeatedly/concurrently -
+     *  Socket.close() is internally guarded (`if (isClosed()) return`), so repeat calls are
+     *  harmless no-ops. */
+    private fun closeBridgeSockets(aaSocket: Socket, tabletSocket: Socket?) {
+        try { aaSocket.close() } catch (e: Exception) {}
+        try { tabletSocket?.close() } catch (e: Exception) {}
     }
 
     private suspend fun pump(input: InputStream, output: OutputStream, name: String) = withContext(Dispatchers.IO) {


### PR DESCRIPTION
## Summary

The bridge's "Connected" indicator only flips off once `launchBridge()`'s `joinAll(job1, job2)` returns. If the tablet side (HUR) closes its socket cleanly - which it now does correctly on "Stop Connection" (see [headunit-revived#739](https://github.com/andreknieriem/headunit-revived/pull/739)) - the tablet-reading pump ends, but the AA-reading pump stays blocked in a `read()` call until Google's Android Auto app itself decides to close its local loopback socket, which isn't guaranteed to happen promptly, or at all, just because HUR sent a `ByeByeRequest`. Nothing closed that socket to unblock the other pump until after `joinAll` already returned - a deadlock, not a timing issue.

Each pump direction now force-closes both sockets as soon as it ends, for any reason. That makes whichever pump is still blocked in `read()` throw immediately (already caught by `pump()`'s own try/catch), so `joinAll` reliably completes and `onDisconnected()` fires. `Socket.close()` is internally guarded against double-close, so the extra calls from both pump completions plus the existing outer `finally` are harmless.

## Test plan

- [x] On-device (Motorola edge 30 neo, Gearhead 17.2, connected via WiFi Direct strategy to a HUR head unit): established a full session, confirmed the "Connected" button showing green, then triggered "Stop Connection" on HUR.
- [x] Confirmed via logcat: `"Bridge closed"` now fires ~6ms after the socket-closed error is detected, immediately followed by `"AA proxy connection lost"` - no hang waiting on the other pump direction.
- [x] Confirmed via screenshot sequence (0.5s intervals): the UI flips from green "CONNECTED" to "START ANDROID AUTO" within ~1-2 seconds of the tap, instead of staying stuck.

https://github.com/o-jcardenass/headunit-revived/releases/download/v.3.2.0-beta3/wirelesshelper_1.9.1-debug2.apk