### PR TITLE
Sync Nearby Connections SERVICE_ID with HUR's rename to Open Headunit

### DIFF
--- a/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyNearby.kt
+++ b/app/src/main/java/com/andrerinas/wirelesshelper/strategy/StrategyNearby.kt
@@ -18,7 +18,7 @@ class StrategyNearby(context: Context, scope: CoroutineScope) : BaseStrategy(con
 
     override val TAG = "HUREV_NEARBY"
     private val connectionsClient = Nearby.getConnectionsClient(context)
-    private val SERVICE_ID = "com.andrerinas.hurev"
+    private val SERVICE_ID = "com.andrerinas.openhu"
     private var activeNearbySocket: NearbySocket? = null
     private var activePipes: Array<android.os.ParcelFileDescriptor>? = null
     private var activeEndpointId: String? = null


### PR DESCRIPTION
## Summary

`headunit-revived`'s `NearbyManager` changed its Nearby Connections `SERVICE_ID` from `com.andrerinas.hurev` to `com.andrerinas.openhu` as part of its ongoing rename to Open Headunit (both are intentional short custom IDs, not derived from the actual package name). Nearby Connections requires both sides to advertise/discover under the exact same `SERVICE_ID` to find each other at all - this app's `StrategyNearby` was still on the old value, which would silently break Nearby-based discovery between the two apps the moment the renamed HUR build ships.

## Test plan

- [x] `./gradlew assembleDebug` - builds clean.
- [x] Confirmed via grep this was the only reference to the old SERVICE_ID anywhere in the app.